### PR TITLE
Extend Cloudflare product icons and repo-side detection

### DIFF
--- a/collect-data.ts
+++ b/collect-data.ts
@@ -38,6 +38,7 @@ const CLOUDFLARE_PACKAGE_PRODUCT_RULES: CloudflarePackageRule[] = [
   { match: "@cloudflare/ai", products: ["Workers AI"] },
   { match: "@cloudflare/ai-gateway", products: ["AI Gateway"] },
   { match: "@cloudflare/ai-search", products: ["AI Search"] },
+  { match: "@cloudflare/analytics-engine", products: ["Analytics"] },
   { match: "@cloudflare/d1", products: ["D1"] },
   { match: "@cloudflare/kv-asset-handler", products: ["KV"] },
   { match: "@cloudflare/queues", products: ["Queues"] },
@@ -46,7 +47,12 @@ const CLOUDFLARE_PACKAGE_PRODUCT_RULES: CloudflarePackageRule[] = [
   { match: "@cloudflare/turnstile", products: ["Turnstile"] },
   { match: "@cloudflare/workers-types", products: ["Workers"] },
   { match: "wrangler", products: ["Workers"] },
+  { prefix: "@cloudflare/containers", products: ["Containers"] },
+  { prefix: "@cloudflare/email-workers", products: ["Email Routing"] },
   { prefix: "@cloudflare/pages", products: ["Pages"] },
+  { prefix: "@cloudflare/sandbox", products: ["Sandbox SDK"] },
+  { prefix: "@cloudflare/secret-store", products: ["Secrets Store"] },
+  { prefix: "@cloudflare/workers-for-platforms", products: ["Cloudflare for Platforms"] },
 ];
 
 interface Author {
@@ -885,6 +891,7 @@ function analyzePyproject(content: string, analysis: RepoAnalysis): void {
 function analyzeWranglerConfig(content: string, analysis: RepoAnalysis): void {
   // Detect Cloudflare products from wrangler config
   const products = new Set(analysis.cloudflare.products);
+  const normalizedContent = content.toLowerCase();
 
   if (content.includes("d1_database") || content.includes('"d1"') || content.includes("'d1'") || content.includes("D1Database")) {
     products.add("D1");
@@ -898,44 +905,62 @@ function analyzeWranglerConfig(content: string, analysis: RepoAnalysis): void {
   if (content.includes("durable_object") || content.includes("durableObjects") || content.includes("DurableObject")) {
     products.add("Durable Objects");
   }
-  if (content.includes("hyperdrive")) {
+  if (normalizedContent.includes("hyperdrive")) {
     products.add("Hyperdrive");
   }
-  if (content.includes("browser") || content.includes("Browser") || content.includes("puppeteer")) {
+  if (normalizedContent.includes("browser") || normalizedContent.includes("puppeteer")) {
     products.add("Browser Rendering");
   }
-  if (content.includes("workflow") || content.includes("Workflow")) {
+  if (normalizedContent.includes("workflow")) {
     products.add("Workflows");
   }
-  if (content.includes("images") || content.includes("Images") || content.includes("IMAGE")) {
+  if (normalizedContent.includes("images") || content.includes("IMAGE")) {
     products.add("Cloudflare Images");
   }
-  if (content.includes("rate_limit") || content.includes("rateLimiting") || content.includes("RateLimit")) {
+  if (normalizedContent.includes("rate_limit") || content.includes("rateLimiting") || content.includes("RateLimit")) {
     products.add("Rate Limiting");
   }
-  if ((content.includes("ai") || content.includes("AI")) && content.includes("binding")) {
+  if ((content.includes("ai") || content.includes("AI")) && normalizedContent.includes("binding")) {
     products.add("Workers AI");
   }
-  if (content.includes("autorag") || content.includes("ai_search") || content.includes("AutoRAG")) {
+  if (normalizedContent.includes("autorag") || normalizedContent.includes("ai_search")) {
     products.add("AI Search");
   }
-  if (content.includes("assets") || content.includes("Assets")) {
+  if (normalizedContent.includes("assets")) {
     products.add("Static Assets");
   }
-  if (content.includes("crons") || content.includes("cron") || content.includes("triggers")) {
+  if (normalizedContent.includes("crons") || normalizedContent.includes("cron") || normalizedContent.includes("triggers")) {
     products.add("Cron Triggers");
   }
-  if (content.includes("turnstile") || content.includes("Turnstile")) {
+  if (normalizedContent.includes("turnstile")) {
     products.add("Turnstile");
   }
-  if (content.includes("realtime") || content.includes("Realtime") || content.includes("calls")) {
+  if (normalizedContent.includes("realtime") || normalizedContent.includes("calls")) {
     products.add("Realtime");
   }
-  if (content.includes("vectorize")) {
+  if (normalizedContent.includes("vectorize")) {
     products.add("Vectorize");
   }
-  if (content.includes("queues")) {
+  if (normalizedContent.includes("queues")) {
     products.add("Queues");
+  }
+  if (normalizedContent.includes("container")) {
+    products.add("Containers");
+  }
+  if (normalizedContent.includes("send_email") || normalizedContent.includes("email_workers") || normalizedContent.includes("email-routing")) {
+    products.add("Email Routing");
+  }
+  if (normalizedContent.includes("analytics_engine")) {
+    products.add("Analytics");
+  }
+  if (normalizedContent.includes("dispatch_namespace") || normalizedContent.includes("workers_for_platforms")) {
+    products.add("Cloudflare for Platforms");
+  }
+  if (normalizedContent.includes("secrets_store") || normalizedContent.includes("secret_store") || normalizedContent.includes("secret-store")) {
+    products.add("Secrets Store");
+  }
+  if (normalizedContent.includes("sandbox")) {
+    products.add("Sandbox SDK");
   }
 
   analysis.cloudflare.products = Array.from(products);

--- a/website/src/components/CloudflareProduct.astro
+++ b/website/src/components/CloudflareProduct.astro
@@ -7,27 +7,39 @@ interface Props {
 
 const { product } = Astro.props;
 
-// Map Cloudflare products to Lucide icons
+// Map Cloudflare products to Lucide icons.
+// Extended from https://github.com/adewale/demoscene to cover more of this repo's catalog.
 const productConfig: Record<string, { icon: string; color: string }> = {
   "Workers": { icon: "lucide:cpu", color: "text-orange-500" },
-  "D1": { icon: "lucide:database", color: "text-blue-500" },
-  "R2": { icon: "lucide:archive", color: "text-purple-500" },
-  "KV": { icon: "lucide:key", color: "text-yellow-600" },
-  "Durable Objects": { icon: "lucide:lock", color: "text-green-600" },
-  "Hyperdrive": { icon: "lucide:zap", color: "text-cyan-500" },
   "Pages": { icon: "lucide:file-text", color: "text-blue-400" },
-  "Workflows": { icon: "lucide:git-branch", color: "text-indigo-500" },
-  "Cloudflare Images": { icon: "lucide:image", color: "text-pink-500" },
-  "Browser Rendering": { icon: "lucide:globe", color: "text-teal-500" },
-  "Rate Limiting": { icon: "lucide:gauge", color: "text-red-500" },
+  "D1": { icon: "lucide:database", color: "text-blue-500" },
+  "KV": { icon: "lucide:key", color: "text-yellow-600" },
+  "R2": { icon: "lucide:archive", color: "text-purple-500" },
+  "Durable Objects": { icon: "lucide:lock", color: "text-green-600" },
+  "Queues": { icon: "lucide:list-ordered", color: "text-indigo-500" },
+  "Workflows": { icon: "lucide:workflow", color: "text-indigo-500" },
+  "Vectorize": { icon: "lucide:radar", color: "text-green-600" },
   "Workers AI": { icon: "lucide:brain", color: "text-violet-500" },
+  "AI Gateway": { icon: "lucide:network", color: "text-fuchsia-500" },
+  "Browser Rendering": { icon: "lucide:monitor", color: "text-teal-500" },
+  "Containers": { icon: "lucide:boxes", color: "text-cyan-500" },
+  "Hyperdrive": { icon: "lucide:rocket", color: "text-cyan-500" },
+  "Cloudflare Images": { icon: "lucide:image", color: "text-pink-500" },
+  "Email Routing": { icon: "lucide:mail", color: "text-red-500" },
+  "Analytics": { icon: "lucide:chart-column", color: "text-emerald-600" },
+  "Cloudflare for Platforms": { icon: "lucide:app-window", color: "text-slate-500" },
+  "Secrets Store": { icon: "lucide:vault", color: "text-lime-500" },
+  "Realtime": { icon: "lucide:radio", color: "text-rose-500" },
+  "Stream": { icon: "lucide:play", color: "text-pink-500" },
+  "Sandbox SDK": { icon: "lucide:square-dashed", color: "text-amber-500" },
+  "Agents": { icon: "lucide:bot", color: "text-orange-400" },
+
+  // Existing small-app-gardener-specific mappings.
+  "Rate Limiting": { icon: "lucide:gauge", color: "text-red-500" },
   "AI Search": { icon: "lucide:search", color: "text-emerald-500" },
   "Static Assets": { icon: "lucide:folder", color: "text-gray-500" },
   "Cron Triggers": { icon: "lucide:clock", color: "text-amber-500" },
   "Turnstile": { icon: "lucide:shield-check", color: "text-green-500" },
-  "Realtime": { icon: "lucide:radio", color: "text-rose-500" },
-  "AI Gateway": { icon: "lucide:network", color: "text-fuchsia-500" },
-  "Agents": { icon: "lucide:bot", color: "text-orange-400" },
 };
 
 const config = productConfig[product] || { icon: "lucide:box", color: "text-gray-400" };


### PR DESCRIPTION
## What

Extend the Cloudflare product icon mapping used by the website, and add matching repo-side product detection in `collect-data.ts` for products that previously only showed up via Garden tags.

## Why

This repo already renders Cloudflare product chips in multiple places, but the icon mapping in `website/src/components/CloudflareProduct.astro` covered only a subset of products in the catalog.

I also found a mismatch between UI support and data detection:

- some products had icons or could appear in the catalog
- but `collect-data.ts` did **not** detect them from repo contents
- they would only appear if the Small App Garden page tagged them explicitly

This PR closes that gap by:
1. bringing over the broader icon mapping from `adewale/demoscene`
2. adding repo-side detection for the missing products so the UI and collector stay aligned

## How

### UI: expand product icon coverage

Updated `website/src/components/CloudflareProduct.astro` to add/align icon mappings for a larger set of Cloudflare products, based on the mapping used in `adewale/demoscene`.

Added or updated mappings for products including:

- Queues
- Workflows
- Vectorize
- Browser Rendering
- Containers
- Hyperdrive
- Email Routing
- Analytics
- Cloudflare for Platforms
- Secrets Store
- Stream
- Sandbox SDK

The existing repo-specific mappings that were not part of the demoscene mapping were kept:

- Rate Limiting
- AI Search
- Static Assets
- Cron Triggers
- Turnstile

### Data collection: add repo-side detection

Updated `collect-data.ts` in two places:

#### 1. Dependency-based detection
Added package rules for:

- `Analytics`
- `Containers`
- `Email Routing`
- `Sandbox SDK`
- `Secrets Store`
- `Cloudflare for Platforms`

#### 2. Wrangler/config-based detection
Added keyword-based detection for:

- `Containers`
- `Email Routing`
- `Analytics`
- `Cloudflare for Platforms`
- `Secrets Store`
- `Sandbox SDK`

I also normalized Wrangler config content to lowercase once before matching, which keeps the detection logic simpler and more consistent.

## Scope

This PR is intentionally limited to one concern:

- improve consistency between Cloudflare product rendering and Cloudflare product detection

It does **not**:
- add new dependencies
- refactor the product chip component into a new shared module
- change page layout or chip styling
- attempt to fix the current Garden scraping issue

## Testing

This project has existing data-validation tests (`npm test`), but it does not currently have targeted tests for Cloudflare product detection heuristics or product icon mappings.

What I verified:
- confirmed Cloudflare product icons are rendered through a single shared component:
  - `website/src/components/CloudflareProduct.astro`
- confirmed that component is used consistently in:
  - homepage leaderboard
  - homepage covered-products table
  - per-app detail page
- ran the Astro app locally and visually checked the updated icon mapping using a temporary local-only preview fixture
- removed that fixture before finalizing the PR so it is **not** part of this diff

Current repo state:
- `npm test` currently fails on an existing repo condition where `apps.json` contains `0` apps:
  - `Error: No apps found in apps.json`

## Risk

Main risk:
- the new repo-side detection is heuristic and may produce false positives if config or dependency names appear in unrelated contexts

Mitigations:
- kept the change narrow and limited to Cloudflare product detection
- reused the existing detection style already used in `collect-data.ts`
- did not mix in unrelated refactors or UI changes

## Files changed

- `collect-data.ts`
- `website/src/components/CloudflareProduct.astro`
