### PR TITLE
Fix Garden slug scraping and restore app data

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1,35 +1,2361 @@
 {
   "lastUpdated": "2026-04-21",
   "source": "https://developers.cloudflare.com/garden/",
-  "totalApps": 0,
-  "apps": [],
+  "totalApps": 15,
+  "apps": [
+    {
+      "name": "Image Editing Arena",
+      "slug": "image-editing-arena",
+      "description": "AI-powered image editing arena. Upload images and apply transformations using cutting-edge models, then compare results side-by-side. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/replicate/image-editing-arena",
+      "author": {
+        "name": "replicate",
+        "github": "replicate",
+        "avatar": "https://avatars.githubusercontent.com/replicate"
+      },
+      "shippedDate": "2025-11-25",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "lucide-react": "^0.554.0",
+          "react": "^19.2.0",
+          "react-dom": "^19.2.0",
+          "recharts": "^3.5.0"
+        },
+        "dev": {
+          "@types/node": "^22.14.0",
+          "@vitejs/plugin-react": "^5.0.0",
+          "typescript": "~5.8.2",
+          "vite": "^6.2.0",
+          "wrangler": "^3.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Image Editing Arena using Replicate",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 7,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 27,
+        "quality": 35,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "BucketDrop",
+      "slug": "bucketdrop",
+      "description": "File uploads from your Mac menu bar. Bring your own R2 bucket. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/fayazara/bucketdrop",
+      "author": {
+        "name": "fayazara",
+        "github": "fayazara",
+        "avatar": "https://avatars.githubusercontent.com/fayazara"
+      },
+      "shippedDate": "2026-01-23",
+      "stack": {
+        "framework": "Unknown",
+        "language": "Unknown",
+        "buildTool": "Unknown",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {},
+        "dev": {}
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "BucketDrop is a tiny, open-source menu bar app for uploading files to your own S3-compatible storage.  No dashboards. No syncing folders. No vendor lock-in.  Just drop a file and get a shareable URL instantly.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 210,
+        "forks": 30
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 78,
+        "quality": 35,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "SYSTEM",
+      "slug": "system",
+      "description": "Control your Mac from anywhere with AI. Play music, send messages, run commands, and automate with Raycast extensions. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/ygwyg/system",
+      "author": {
+        "name": "ygwyg",
+        "github": "ygwyg",
+        "avatar": "https://avatars.githubusercontent.com/ygwyg"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Express",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@modelcontextprotocol/sdk": "^1.0.4",
+          "chalk": "^5.6.2",
+          "enquirer": "^2.4.1",
+          "express": "^4.18.2",
+          "open": "^10.0.3",
+          "zod": "^3.22.4",
+          "@tauri-apps/plugin-shell": "^2.3.3",
+          "react": "^18.2.0",
+          "react-dom": "^18.2.0"
+        },
+        "dev": {
+          "@eslint/js": "^9.39.2",
+          "@types/express": "^4.17.21",
+          "@types/node": "^20.10.0",
+          "@vitest/coverage-v8": "^4.0.16",
+          "eslint": "^9.39.2",
+          "eslint-config-prettier": "^10.1.8",
+          "husky": "^9.1.7",
+          "lint-staged": "^16.2.7",
+          "prettier": "^3.7.4",
+          "tsx": "^4.7.0",
+          "typescript": "^5.3.0",
+          "typescript-eslint": "^8.52.0",
+          "vitest": "^4.0.16",
+          "@tauri-apps/api": "^2.0.0",
+          "@tauri-apps/cli": "^2.0.0",
+          "@types/react": "^18.2.0",
+          "@types/react-dom": "^18.2.0",
+          "@vitejs/plugin-react": "^4.2.0",
+          "vite": "^5.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "src/bridge/tools/__tests__/command.test.ts",
+          "src/bridge/tools/__tests__/tools.test.ts",
+          "src/bridge/tools/__tests__/validation.test.ts",
+          "src/bridge/tools/__tests__/volume.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Control your mac from anywhere with AI",
+        "hasWebsite": true,
+        "websiteUrl": "https://system.surf",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 298,
+        "forks": 13
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 67,
+        "quality": 50,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system/blob/HEAD/src/bridge/tools/__tests__/command.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://system.surf"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Fauxto Booth",
+      "slug": "fauxto-booth",
+      "description": "Take Fake Photos with your real friends! Discover what developers are building on Cloudflare.",
+      "url": "https://fauxto-booth.craigsdemos.workers.dev",
+      "github": "https://github.com/craigsdennis/fauxto-booth",
+      "author": {
+        "name": "craigsdennis",
+        "github": "craigsdennis",
+        "avatar": "https://avatars.githubusercontent.com/craigsdennis"
+      },
+      "shippedDate": "2025-12-22",
+      "youtubeVideo": "https://youtube.com/watch?v=JvoGnXEKzfc",
+      "stack": {
+        "framework": "React + Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@tailwindcss/vite": "^4.1.17",
+          "agents": "^0.2.28",
+          "ai": "^5.0.106",
+          "hono": "^4.10.7",
+          "hono-agents": "^2.0.7",
+          "qrcode": "^1.5.4",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "replicate": "^1.4.0",
+          "tailwindcss": "^4.1.17"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.16.1",
+          "@eslint/js": "^9.33.0",
+          "@types/node": "^24.10.1",
+          "@types/qrcode": "^1.5.6",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react": "^5.0.0",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^5.2.0",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^16.3.0",
+          "typescript": "~5.8.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "wrangler": "^4.56.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Agents",
+          "R2",
+          "Durable Objects",
+          "Workflows",
+          "Cloudflare Images",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "bytedance/seedream-4.5"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "A fake photo booth. Didn't really happen. But it could have.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 18,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 35,
+        "quality": 65,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LinkedOut",
+      "slug": "linkedout",
+      "description": "Share your links after talks and track every click with analytics Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/craigsdennis/linkedout-pipelines",
+      "author": {
+        "name": "craigsdennis",
+        "github": "craigsdennis",
+        "avatar": "https://avatars.githubusercontent.com/craigsdennis"
+      },
+      "shippedDate": "2026-01-20",
+      "youtubeVideo": "https://youtube.com/watch?v=pkS1ccQBoqg",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "common-tags": "^1.8.2",
+          "hono": "^4.12.3",
+          "marked": "^17.0.3",
+          "qrcode": "^1.5.4",
+          "tsx": "^4.21.0"
+        },
+        "dev": {
+          "@biomejs/biome": "2.4.4",
+          "@cloudflare/vitest-pool-workers": "^0.12.18",
+          "@types/common-tags": "^1.8.4",
+          "@types/qrcode": "^1.5.6",
+          "typescript": "^5.9.3",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.69.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/auth.test.ts",
+          "test/env.d.ts",
+          "test/helpers.test.ts",
+          "test/middleware/auth.test.ts",
+          "test/routes/dashboard.test.ts",
+          "test/routes/public.test.ts",
+          "test/schema.test.ts",
+          "test/tsconfig.json",
+          "test/types.test.ts",
+          "test/utils/analytics-cache.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "KV",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "A way to share external links and track interactions using Cloudflare Pipelines",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 23,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 31,
+        "quality": 65,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/test/auth.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "The Coffee Cluster",
+      "slug": "the-coffee-cluster",
+      "description": "An example Next.js application for PlanetScale with Hyperdrive Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/jillesme/thecoffeecluster",
+      "author": {
+        "name": "jillesme",
+        "github": "jillesme",
+        "avatar": "https://avatars.githubusercontent.com/jillesme"
+      },
+      "shippedDate": "2025-11-24",
+      "youtubeVideo": "https://youtube.com/watch?v=Xps8IAlZ5a8",
+      "stack": {
+        "framework": "Next.js 15",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "pnpm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "orm": "Drizzle ORM"
+      },
+      "dependencies": {
+        "runtime": {
+          "@opennextjs/cloudflare": "^1.17.1",
+          "@planetscale/database": "^1.19.0",
+          "@radix-ui/react-slot": "^1.2.4",
+          "@radix-ui/react-toggle": "^1.1.10",
+          "class-variance-authority": "^0.7.1",
+          "clsx": "^2.1.1",
+          "drizzle-orm": "^0.45.1",
+          "js-cookie": "^3.0.5",
+          "lucide-react": "^0.575.0",
+          "next": "15.5.10",
+          "next-themes": "^0.4.6",
+          "pg": "^8.19.0",
+          "react": "19.2.4",
+          "react-dom": "19.2.4",
+          "sonner": "^2.0.7",
+          "tailwind-merge": "^3.5.0",
+          "zustand": "^5.0.11"
+        },
+        "dev": {
+          "@eslint/eslintrc": "^3.3.4",
+          "@tailwindcss/postcss": "^4.2.1",
+          "@testing-library/jest-dom": "^6.9.1",
+          "@testing-library/react": "^16.3.2",
+          "@testing-library/user-event": "^14.6.1",
+          "@types/js-cookie": "^3.0.6",
+          "@types/node": "^25.3.2",
+          "@types/react": "^19.2.14",
+          "@types/react-dom": "^19",
+          "@vitejs/plugin-react": "^5.1.4",
+          "@vitest/coverage-v8": "^4.0.18",
+          "dotenv": "^17.3.1",
+          "drizzle-kit": "^0.31.9",
+          "eslint": "^9.39.1",
+          "eslint-config-next": "15.5.10",
+          "jsdom": "^28.1.0",
+          "tailwindcss": "^4.2.1",
+          "tsx": "^4.21.0",
+          "tw-animate-css": "^1.4.0",
+          "typescript": "^5",
+          "vitest": "^4.0.18",
+          "wrangler": "^4.69.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "src/app/api/beans/[id]/route.test.ts",
+          "src/app/api/beans/route.test.ts",
+          "src/components/coffee-bean-card.test.tsx",
+          "src/lib/latency-store.test.ts",
+          "src/lib/utils.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "Hyperdrive",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Cloudflare Worker <-> PlanetScale <-> Hyperdrive",
+        "hasWebsite": true,
+        "websiteUrl": "https://thecoffeecluster.com/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 7,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 27,
+        "quality": 70,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/src/app/api/beans/[id]/route.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/.github/workflows/ci.yml"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://thecoffeecluster.com/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Virtual Try On",
+      "slug": "virtual-try-on",
+      "description": "An app that allows users to try on an ugly winter jumper, virtually! Built with Workers and Replicate Discover what developers are building on Cloudflare.",
+      "url": "https://virtual-try-on.h-demo.workers.dev/",
+      "github": "https://github.com/harshil1712/virtual-try-on-demo",
+      "author": {
+        "name": "harshil1712",
+        "github": "harshil1712",
+        "avatar": "https://avatars.githubusercontent.com/harshil1712"
+      },
+      "shippedDate": "2025-12-23",
+      "stack": {
+        "framework": "React + Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null,
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.11.1",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "replicate": "^1.4.0"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.18.0",
+          "@eslint/js": "^9.33.0",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react-swc": "^4.0.0",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^5.2.0",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^16.3.0",
+          "typescript": "~5.8.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "wrangler": "^4.55.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "google/nano-banana-pro",
+          "openai/gpt-image-1.5"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Virtual try-on app for ugly winter jumpers, built with Workers and Replicate",
+        "hasWebsite": true,
+        "websiteUrl": "https://virtual-try-on.h-demo.workers.dev/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 9,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 32,
+        "quality": 50,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://virtual-try-on.h-demo.workers.dev/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Site Confidence",
+      "slug": "site-confidence",
+      "description": "Analyze website performance with detailed metrics, waterfall charts, and video recordings, all built on Cloudflare's serverless platform. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/TrickeySolutions/site-page-test",
+      "author": {
+        "name": "TrickeySolutions",
+        "github": "TrickeySolutions",
+        "avatar": "https://avatars.githubusercontent.com/TrickeySolutions"
+      },
+      "shippedDate": "2026-01-12",
+      "stack": {
+        "framework": "Astro",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS"
+      },
+      "dependencies": {
+        "runtime": {
+          "@cloudflare/puppeteer": "^1.0.4",
+          "@astrojs/react": "^4.2.0",
+          "@astrojs/tailwind": "^6.0.0",
+          "astro": "^5.1.0",
+          "react": "^19.0.0",
+          "react-dom": "^19.0.0",
+          "tailwindcss": "^3.4.0"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.8.19",
+          "@cloudflare/workers-types": "^4.20241127.0",
+          "typescript": "^5.5.2",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.56.0",
+          "@types/react": "^19.0.0",
+          "@types/react-dom": "^19.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/env.d.ts",
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "R2",
+          "Durable Objects",
+          "Browser Rendering",
+          "Workflows",
+          "Workers AI",
+          "Static Assets",
+          "Containers",
+          "Analytics"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": false,
+        "description": null,
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 2,
+        "forks": 1
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 16,
+        "quality": 30,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/test/env.d.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Kivo",
+      "slug": "kivo",
+      "description": "A modern invoicing platform for freelancers and creators. Create professional invoices, track payments, and get paid faster. Discover what developers are building on Cloudflare.",
+      "url": "https://kivo.lauragift.workers.dev",
+      "github": "https://github.com/lauragift21/kivo",
+      "author": {
+        "name": "lauragift21",
+        "github": "lauragift21",
+        "avatar": "https://avatars.githubusercontent.com/lauragift21"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@kivo/shared": "*",
+          "hono": "^4.0.0",
+          "stripe": "^14.10.0",
+          "@fontsource/geist-sans": "^5.2.5",
+          "@fontsource/instrument-serif": "^5.2.8",
+          "@hookform/resolvers": "^3.3.4",
+          "@radix-ui/react-alert-dialog": "^1.0.5",
+          "@radix-ui/react-dialog": "^1.0.5",
+          "@radix-ui/react-dropdown-menu": "^2.0.6",
+          "@radix-ui/react-label": "^2.0.2",
+          "@radix-ui/react-select": "^2.0.0",
+          "@radix-ui/react-slot": "^1.0.2",
+          "@radix-ui/react-tabs": "^1.0.4",
+          "@radix-ui/react-toast": "^1.1.5",
+          "@radix-ui/react-tooltip": "^1.0.7",
+          "@tanstack/react-query": "^5.17.0",
+          "@tanstack/react-router": "^1.15.0",
+          "class-variance-authority": "^0.7.0",
+          "clsx": "^2.1.0",
+          "date-fns": "^3.2.0",
+          "lucide-react": "^0.309.0",
+          "react": "^18.2.0",
+          "react-dom": "^18.2.0",
+          "react-hook-form": "^7.49.3",
+          "tailwind-merge": "^2.2.0",
+          "zod": "^3.22.4"
+        },
+        "dev": {
+          "@types/node": "^20.10.0",
+          "concurrently": "^8.2.2",
+          "eslint": "^8.55.0",
+          "typescript": "^5.3.3",
+          "wrangler": "^4.54.0",
+          "@cloudflare/workers-types": "^4.20240117.0",
+          "vitest": "^1.1.0",
+          "@types/react": "^18.2.47",
+          "@types/react-dom": "^18.2.18",
+          "@vitejs/plugin-react": "^4.2.1",
+          "autoprefixer": "^10.4.16",
+          "postcss": "^8.4.33",
+          "tailwindcss": "^3.4.1",
+          "vite": "^5.0.11"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "apps/api/src/durable-objects/reminder-scheduler.test.ts",
+          "packages/shared/src/utils.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "deploy.yml",
+          "opencode.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "R2",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets",
+          "Cron Triggers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Modern invoicing for freelancers and independent creators.",
+        "hasWebsite": true,
+        "websiteUrl": "https://kivo.lauragift.workers.dev",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 15,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 34,
+        "quality": 90,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/apps/api/src/durable-objects/reminder-scheduler.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/tree/HEAD/.github/workflows"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://kivo.lauragift.workers.dev"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "InboxBuddy",
+      "slug": "inboxbuddy",
+      "description": "AI-powered scheduling assistant. Just CC the bot in any email and it handles meeting coordination, calendar checks, and booking automatically. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/whoiskatrin/inboxbuddy",
+      "author": {
+        "name": "whoiskatrin",
+        "github": "whoiskatrin",
+        "avatar": "https://avatars.githubusercontent.com/whoiskatrin"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@anthropic-ai/sdk": "^0.71.2",
+          "agents": "^0.3.3",
+          "mimetext": "^3.0.27",
+          "postal-mime": "^2.7.1"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.8.19",
+          "@types/node": "^25.0.3",
+          "typescript": "^5.5.2",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.54.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/env.d.ts",
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Agents",
+          "D1",
+          "KV",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets",
+          "Email Routing"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "AI Scheduling Assistant ",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 27,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 32,
+        "quality": 45,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/test/env.d.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Weft",
+      "slug": "weft",
+      "description": "Task management where AI agents do your tasks. Create tasks, assign them to agents, and they work on emails, spreadsheets, PRs, and code. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/jonesphillip/weft",
+      "author": {
+        "name": "jonesphillip",
+        "github": "jonesphillip",
+        "avatar": "https://avatars.githubusercontent.com/jonesphillip"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null,
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@anthropic-ai/sdk": "^0.71.2",
+          "@cloudflare/sandbox": "^0.6.7",
+          "jose": "^6.1.3",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "react-router-dom": "^7.11.0",
+          "zod": "^4.3.4"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.13.13",
+          "@cloudflare/vitest-pool-workers": "^0.11.1",
+          "@eslint/js": "^9.33.0",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react-swc": "^4.0.0",
+          "@vitest/coverage-v8": "3.2",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^7.0.1",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^17.0.0",
+          "typescript": "^5.9.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "vitest": "3.2",
+          "wrangler": "^4.54.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "tests/mocks/cloudflare-sandbox.ts",
+          "tests/worker/auth.test.ts",
+          "tests/worker/board-access.integration.test.ts",
+          "tests/worker/user-isolation.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Sandbox SDK",
+          "Durable Objects",
+          "Workflows",
+          "Workers AI",
+          "Static Assets",
+          "Containers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Task management, but AI agents do your tasks. Self-host on Cloudflare.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": "Apache-2.0",
+        "licensePath": "LICENSE",
+        "stars": 494,
+        "forks": 50
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 90,
+        "quality": 55,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/tests/mocks/cloudflare-sandbox.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Localflare",
+      "slug": "localflare",
+      "description": "Local development dashboard for Cloudflare Workers that lets you inspect and interact with D1, KV, R2, Durable Objects, and Queues during development. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/rohanprasadofficial/localflare",
+      "author": {
+        "name": "rohanprasadofficial",
+        "github": "rohanprasadofficial",
+        "avatar": "https://avatars.githubusercontent.com/rohanprasadofficial"
+      },
+      "shippedDate": "2025-12-29",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "pnpm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.6.14",
+          "cac": "^6.7.14",
+          "ink": "^6.6.0",
+          "ink-spinner": "^5.0.0",
+          "localflare-api": "workspace:*",
+          "localflare-core": "workspace:*",
+          "open": "^10.1.0",
+          "picocolors": "^1.1.1",
+          "react": "^19.0.0",
+          "tiny-jsonc": "^1.0.2",
+          "toml": "^3.0.0",
+          "@base-ui/react": "^1.0.0",
+          "@cloudflare/kumo": "^1.9.0",
+          "@codemirror/autocomplete": "^6.20.0",
+          "@codemirror/commands": "^6.10.1",
+          "@codemirror/lang-sql": "^6.10.0",
+          "@codemirror/state": "^6.5.3",
+          "@codemirror/theme-one-dark": "^6.1.3",
+          "@codemirror/view": "^6.39.8",
+          "@faker-js/faker": "^10.1.0",
+          "@fontsource-variable/figtree": "^5.2.10",
+          "@hugeicons/core-free-icons": "^3.1.0",
+          "@hugeicons/react": "^1.1.4",
+          "@phosphor-icons/react": "^2.1.10",
+          "@radix-ui/react-checkbox": "^1.3.3",
+          "@radix-ui/react-collapsible": "^1.1.12",
+          "@radix-ui/react-dialog": "^1.1.15",
+          "@radix-ui/react-dropdown-menu": "^2.1.16",
+          "@radix-ui/react-popover": "^1.1.15",
+          "@radix-ui/react-scroll-area": "^1.2.2",
+          "@radix-ui/react-select": "^2.2.6",
+          "@radix-ui/react-slot": "^1.1.1",
+          "@radix-ui/react-tabs": "^1.1.2",
+          "@tailwindcss/vite": "^4.1.17",
+          "@tanstack/react-query": "^5.62.8",
+          "@tanstack/react-table": "^8.20.6",
+          "aws4fetch": "^1.0.20",
+          "class-variance-authority": "^0.7.1",
+          "clsx": "^2.1.1",
+          "codemirror": "^6.0.2",
+          "lucide-react": "^0.562.0",
+          "react-dom": "^19.0.0",
+          "react-grid-layout": "^2.2.2",
+          "react-resizable-panels": "^4.4.1",
+          "react-router-dom": "^7.1.1",
+          "recharts": "^2.15.4",
+          "sonner": "^2.0.7",
+          "tailwind-merge": "^3.4.0",
+          "tailwindcss": "^4.1.17",
+          "tw-animate-css": "^1.4.0"
+        },
+        "dev": {
+          "@types/node": "^22.10.2",
+          "turbo": "^2.3.3",
+          "typescript": "^5.7.2",
+          "@cloudflare/workers-types": "^4.20241218.0",
+          "localflare-core": "workspace:*",
+          "tsup": "^8.3.5",
+          "@types/react": "^19.0.2",
+          "@types/react-dom": "^19.0.2",
+          "@types/react-grid-layout": "^2.1.0",
+          "@vitejs/plugin-react": "^4.3.4",
+          "vite": "^6.0.6",
+          "wrangler": "^3.99.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "local cloudflare",
+        "hasWebsite": true,
+        "websiteUrl": "https://localflare.dev",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 1519,
+        "forks": 70
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 100,
+        "quality": 60,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://localflare.dev"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Keyboardia",
+      "slug": "keyboardia",
+      "description": "A multiplayer step sequencer with polyrhythmic patterns, built for real-time collaboration. Create/Collaborate. Remix. Share. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/adewale/keyboardia",
+      "author": {
+        "name": "adewale",
+        "github": "adewale",
+        "avatar": "https://avatars.githubusercontent.com/adewale"
+      },
+      "shippedDate": "2025-12-17",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@types/qrcode": "^1.5.6",
+          "midi-writer-js": "^3.1.1",
+          "qrcode": "^1.5.4",
+          "react": "^19.2.1",
+          "react-dom": "^19.2.1",
+          "tone": "^15.1.22",
+          "workers-og": "^0.0.27"
+        },
+        "dev": {
+          "@eslint/js": "^9.39.1",
+          "@playwright/test": "^1.57.0",
+          "@testing-library/react": "^16.3.0",
+          "@types/node": "^24.10.1",
+          "@types/react": "^19.2.7",
+          "@types/react-dom": "^19.2.3",
+          "@vitejs/plugin-react": "^5.1.1",
+          "eslint": "^9.39.1",
+          "eslint-plugin-react-hooks": "^7.0.1",
+          "eslint-plugin-react-refresh": "^0.4.24",
+          "fast-check": "^4.5.3",
+          "globals": "^16.5.0",
+          "husky": "^9.1.7",
+          "jsdom": "^27.3.0",
+          "lint-staged": "^16.2.7",
+          "midi-file": "^1.2.4",
+          "ts-morph": "^27.0.2",
+          "tsx": "^4.21.0",
+          "typescript": "~5.9.3",
+          "typescript-eslint": "^8.46.4",
+          "vite": "^7.2.4",
+          "vitest": "^4.0.15",
+          "wrangler": "^4.53.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest + playwright",
+        "testFiles": [
+          "app/e2e/accessibility.spec.ts",
+          "app/e2e/chromatic-grid.spec.ts",
+          "app/e2e/connection-storm.spec.ts",
+          "app/e2e/core.spec.ts",
+          "app/e2e/drag-to-paint.spec.ts",
+          "app/e2e/feature-flags.spec.ts",
+          "app/e2e/keyboard.spec.ts",
+          "app/e2e/landscape-alignment.spec.ts",
+          "app/e2e/last-cell-flicker.spec.ts",
+          "app/e2e/mobile-android.spec.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "KV",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Multiplayer step sequencer with polyrhythmic patterns for real-time collaboration",
+        "hasWebsite": true,
+        "websiteUrl": "https://keyboardia.dev/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 2,
+        "forks": 0
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 5,
+        "quality": 60,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/app/e2e/accessibility.spec.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/.github/workflows/ci.yml"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://keyboardia.dev/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Webhookflare",
+      "slug": "webhookflare",
+      "description": "Webhook testing and debugging tool built with Cloudflare Durable Objects, demonstrating the power of edge computing with persistent SQLite storage and real-time WebSocket updates. Discover what developers are building on Cloudflare.",
+      "url": "https://webhookflare.fayaz.workers.dev/",
+      "github": "https://github.com/fayazara/webhookflare",
+      "author": {
+        "name": "fayazara",
+        "github": "fayazara",
+        "avatar": "https://avatars.githubusercontent.com/fayazara"
+      },
+      "shippedDate": "2025-11-19",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "pnpm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {},
+        "dev": {
+          "typescript": "^5.5.2",
+          "wrangler": "^4.47.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Durable Objects",
+          "Rate Limiting",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": false,
+        "description": null,
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 8,
+        "forks": 5
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 38,
+        "quality": 20,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/webhookflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/webhookflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Kontext Realtime",
+      "slug": "kontext-realtime",
+      "description": "Create and edit images using your voice. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/replicate/kontext-realtime",
+      "author": {
+        "name": "replicate",
+        "github": "replicate",
+        "avatar": "https://avatars.githubusercontent.com/replicate"
+      },
+      "shippedDate": "2025-07-02",
+      "youtubeVideo": "https://youtube.com/watch?v=72mD_vkG9FU",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.6.13",
+          "replicate": "^2.0.0-alpha.16"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.5.2",
+          "typescript": "^5.5.2",
+          "vitest": "2.1.8",
+          "wrangler": "^4.6.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml",
+          "claude.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Static Assets",
+          "Realtime"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "black-forest-labs/flux-kontext-pro",
+          "black-forest-labs/flux-schnell",
+          "topazlabs/image-upscale"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Create and edit images using your voice",
+        "hasWebsite": true,
+        "websiteUrl": "https://replicate.com/docs/guides/openai-realtime",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 106,
+        "forks": 26
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 73,
+        "quality": 70,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/test/index.spec.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/tree/HEAD/.github/workflows"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://replicate.com/docs/guides/openai-realtime"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    }
+  ],
   "summary": {
-    "byFramework": {},
-    "byLanguage": {},
-    "byPackageManager": {},
-    "byBuildTool": {},
-    "cloudflareProducts": {},
+    "byFramework": {
+      "React 19": 3,
+      "Unknown": 1,
+      "Express": 1,
+      "React + Hono": 2,
+      "Hono": 3,
+      "Next.js 15": 1,
+      "Astro": 1,
+      "Workers": 3
+    },
+    "byLanguage": {
+      "TypeScript": 14,
+      "Unknown": 1
+    },
+    "byPackageManager": {
+      "npm": 12,
+      "pnpm": 3
+    },
+    "byBuildTool": {
+      "Vite": 9,
+      "Unknown": 1,
+      "wrangler": 5
+    },
+    "cloudflareProducts": {
+      "Workers": 15,
+      "Static Assets": 13,
+      "Agents": 2,
+      "R2": 6,
+      "Durable Objects": 7,
+      "Workflows": 3,
+      "Cloudflare Images": 1,
+      "Workers AI": 11,
+      "D1": 4,
+      "KV": 3,
+      "Hyperdrive": 1,
+      "Browser Rendering": 1,
+      "Containers": 2,
+      "Analytics": 1,
+      "Cron Triggers": 1,
+      "Email Routing": 1,
+      "Sandbox SDK": 1,
+      "Rate Limiting": 1,
+      "Realtime": 1
+    },
     "testing": {
-      "withTests": 0,
-      "withoutTests": 0,
-      "testFrameworks": {}
+      "withTests": 9,
+      "withoutTests": 6,
+      "testFrameworks": {
+        "vitest": 9,
+        "playwright": 1
+      }
     },
     "ci": {
-      "withGitHubActions": 0,
-      "withoutGitHubActions": 0
+      "withGitHubActions": 4,
+      "withoutGitHubActions": 11
     },
     "replicate": {
-      "appsUsingReplicate": 0,
-      "totalModels": 0,
-      "uniqueModels": []
+      "appsUsingReplicate": 3,
+      "totalModels": 6,
+      "uniqueModels": [
+        "black-forest-labs/flux-kontext-pro",
+        "black-forest-labs/flux-schnell",
+        "bytedance/seedream-4.5",
+        "google/nano-banana-pro",
+        "openai/gpt-image-1.5",
+        "topazlabs/image-upscale"
+      ]
     },
     "hygiene": {
-      "withDescription": 0,
-      "withWebsite": 0,
-      "withReadme": 0,
-      "withAgentsMd": 0,
-      "withImage": 0,
-      "withVideo": 0
+      "withDescription": 13,
+      "withWebsite": 7,
+      "withReadme": 15,
+      "withAgentsMd": 3,
+      "withImage": 12,
+      "withVideo": 5
     },
     "scores": {
       "popularity": {

--- a/collect-data.ts
+++ b/collect-data.ts
@@ -14,6 +14,7 @@ import { writeFileSync, existsSync, rmSync, readdirSync, statSync, readFileSync 
 import { execSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";
+import { pathToFileURL } from "url";
 import { CLOUDFLARE_PRODUCT_CATALOG, type App } from "./schema";
 import {
   buildQualityBreakdown,
@@ -144,26 +145,40 @@ async function fetchText(url: string): Promise<string> {
   return response.text();
 }
 
+export function parseGardenSlugs(html: string): string[] {
+  const slugs = new Set<string>();
+  const slugPatterns = [
+    /href="\/garden\/([^"\/]+)"/g,
+    /data-slug="([^"]+)"/g,
+    /href="\/([^"\/?#]+)\/"/g,
+  ];
+
+  for (const pattern of slugPatterns) {
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+      const slug = match[1];
+      if (
+        slug &&
+        !slug.startsWith("?") &&
+        slug !== "images" &&
+        slug !== "submit"
+      ) {
+        slugs.add(slug);
+      }
+    }
+  }
+
+  return [...slugs];
+}
+
 // Fetch the garden page and extract app slugs
 async function fetchGardenSlugs(): Promise<string[]> {
   console.log("Fetching garden page...");
   const html = await fetchText(GARDEN_URL);
+  const slugs = parseGardenSlugs(html);
 
-  // Extract app cards from the HTML
-  // Look for links to /garden/{slug} pages
-  const appLinkRegex = /href="\/garden\/([^"\/]+)"/g;
-  const slugs = new Set<string>();
-
-  let match;
-  while ((match = appLinkRegex.exec(html)) !== null) {
-    const slug = match[1];
-    if (slug && !slug.startsWith("?") && slug !== "images") {
-      slugs.add(slug);
-    }
-  }
-
-  console.log(`Found ${slugs.size} app slugs`);
-  return [...slugs];
+  console.log(`Found ${slugs.length} app slugs`);
+  return slugs;
 }
 
 async function fetchGardenApps(): Promise<AppBasicInfo[]> {
@@ -231,7 +246,7 @@ async function checkForAppChanges(): Promise<void> {
 
 async function fetchAppDetails(slug: string): Promise<AppBasicInfo | null> {
   console.log(`  Fetching details for ${slug}...`);
-  const url = `${GARDEN_URL}${slug}`;
+  const url = `${GARDEN_URL}${slug}/`;
   const html = await fetchText(url);
 
   // Extract app name from <h1> or <title>
@@ -1213,4 +1228,7 @@ async function main() {
   console.log(`Wrote ${apps.length} apps to apps.json`);
 }
 
-main().catch(console.error);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(console.error);
+}
+

--- a/test.ts
+++ b/test.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { validateAppsData } from "./schema.js";
+import { parseGardenSlugs } from "./collect-data.ts";
 
 let passed = 0;
 let failed = 0;
@@ -27,6 +28,16 @@ function assert(condition: boolean, message: string) {
     throw new Error(message);
   }
 }
+
+// Test: collector parses current Garden card structure
+
+test("parseGardenSlugs supports current Garden card markup", () => {
+  const html = `<div data-slug="inboxbuddy"><a href="/inboxbuddy/">InboxBuddy</a></div><a href="/submit">Suggest an app</a>`;
+
+  const slugs = parseGardenSlugs(html);
+  assert(slugs.includes("inboxbuddy"), "Missing inboxbuddy slug");
+  assert(!slugs.includes("submit"), "Included submit CTA as an app slug");
+});
 
 // Test: apps.json exists
 test("apps.json exists", () => {

--- a/website/src/data.json
+++ b/website/src/data.json
@@ -1,35 +1,2361 @@
 {
   "lastUpdated": "2026-04-21",
   "source": "https://developers.cloudflare.com/garden/",
-  "totalApps": 0,
-  "apps": [],
+  "totalApps": 15,
+  "apps": [
+    {
+      "name": "Image Editing Arena",
+      "slug": "image-editing-arena",
+      "description": "AI-powered image editing arena. Upload images and apply transformations using cutting-edge models, then compare results side-by-side. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/replicate/image-editing-arena",
+      "author": {
+        "name": "replicate",
+        "github": "replicate",
+        "avatar": "https://avatars.githubusercontent.com/replicate"
+      },
+      "shippedDate": "2025-11-25",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "lucide-react": "^0.554.0",
+          "react": "^19.2.0",
+          "react-dom": "^19.2.0",
+          "recharts": "^3.5.0"
+        },
+        "dev": {
+          "@types/node": "^22.14.0",
+          "@vitejs/plugin-react": "^5.0.0",
+          "typescript": "~5.8.2",
+          "vite": "^6.2.0",
+          "wrangler": "^3.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Image Editing Arena using Replicate",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 7,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 27,
+        "quality": 35,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/replicate/image-editing-arena"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "BucketDrop",
+      "slug": "bucketdrop",
+      "description": "File uploads from your Mac menu bar. Bring your own R2 bucket. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/fayazara/bucketdrop",
+      "author": {
+        "name": "fayazara",
+        "github": "fayazara",
+        "avatar": "https://avatars.githubusercontent.com/fayazara"
+      },
+      "shippedDate": "2026-01-23",
+      "stack": {
+        "framework": "Unknown",
+        "language": "Unknown",
+        "buildTool": "Unknown",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {},
+        "dev": {}
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "BucketDrop is a tiny, open-source menu bar app for uploading files to your own S3-compatible storage.  No dashboards. No syncing folders. No vendor lock-in.  Just drop a file and get a shareable URL instantly.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 210,
+        "forks": 30
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 78,
+        "quality": 35,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/fayazara/bucketdrop"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "SYSTEM",
+      "slug": "system",
+      "description": "Control your Mac from anywhere with AI. Play music, send messages, run commands, and automate with Raycast extensions. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/ygwyg/system",
+      "author": {
+        "name": "ygwyg",
+        "github": "ygwyg",
+        "avatar": "https://avatars.githubusercontent.com/ygwyg"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Express",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@modelcontextprotocol/sdk": "^1.0.4",
+          "chalk": "^5.6.2",
+          "enquirer": "^2.4.1",
+          "express": "^4.18.2",
+          "open": "^10.0.3",
+          "zod": "^3.22.4",
+          "@tauri-apps/plugin-shell": "^2.3.3",
+          "react": "^18.2.0",
+          "react-dom": "^18.2.0"
+        },
+        "dev": {
+          "@eslint/js": "^9.39.2",
+          "@types/express": "^4.17.21",
+          "@types/node": "^20.10.0",
+          "@vitest/coverage-v8": "^4.0.16",
+          "eslint": "^9.39.2",
+          "eslint-config-prettier": "^10.1.8",
+          "husky": "^9.1.7",
+          "lint-staged": "^16.2.7",
+          "prettier": "^3.7.4",
+          "tsx": "^4.7.0",
+          "typescript": "^5.3.0",
+          "typescript-eslint": "^8.52.0",
+          "vitest": "^4.0.16",
+          "@tauri-apps/api": "^2.0.0",
+          "@tauri-apps/cli": "^2.0.0",
+          "@types/react": "^18.2.0",
+          "@types/react-dom": "^18.2.0",
+          "@vitejs/plugin-react": "^4.2.0",
+          "vite": "^5.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "src/bridge/tools/__tests__/command.test.ts",
+          "src/bridge/tools/__tests__/tools.test.ts",
+          "src/bridge/tools/__tests__/validation.test.ts",
+          "src/bridge/tools/__tests__/volume.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Control your mac from anywhere with AI",
+        "hasWebsite": true,
+        "websiteUrl": "https://system.surf",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 298,
+        "forks": 13
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 67,
+        "quality": 50,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system/blob/HEAD/src/bridge/tools/__tests__/command.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/ygwyg/system"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://system.surf"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Fauxto Booth",
+      "slug": "fauxto-booth",
+      "description": "Take Fake Photos with your real friends! Discover what developers are building on Cloudflare.",
+      "url": "https://fauxto-booth.craigsdemos.workers.dev",
+      "github": "https://github.com/craigsdennis/fauxto-booth",
+      "author": {
+        "name": "craigsdennis",
+        "github": "craigsdennis",
+        "avatar": "https://avatars.githubusercontent.com/craigsdennis"
+      },
+      "shippedDate": "2025-12-22",
+      "youtubeVideo": "https://youtube.com/watch?v=JvoGnXEKzfc",
+      "stack": {
+        "framework": "React + Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@tailwindcss/vite": "^4.1.17",
+          "agents": "^0.2.28",
+          "ai": "^5.0.106",
+          "hono": "^4.10.7",
+          "hono-agents": "^2.0.7",
+          "qrcode": "^1.5.4",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "replicate": "^1.4.0",
+          "tailwindcss": "^4.1.17"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.16.1",
+          "@eslint/js": "^9.33.0",
+          "@types/node": "^24.10.1",
+          "@types/qrcode": "^1.5.6",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react": "^5.0.0",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^5.2.0",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^16.3.0",
+          "typescript": "~5.8.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "wrangler": "^4.56.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Agents",
+          "R2",
+          "Durable Objects",
+          "Workflows",
+          "Cloudflare Images",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "bytedance/seedream-4.5"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "A fake photo booth. Didn't really happen. But it could have.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 18,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 35,
+        "quality": 65,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/fauxto-booth/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LinkedOut",
+      "slug": "linkedout",
+      "description": "Share your links after talks and track every click with analytics Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/craigsdennis/linkedout-pipelines",
+      "author": {
+        "name": "craigsdennis",
+        "github": "craigsdennis",
+        "avatar": "https://avatars.githubusercontent.com/craigsdennis"
+      },
+      "shippedDate": "2026-01-20",
+      "youtubeVideo": "https://youtube.com/watch?v=pkS1ccQBoqg",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "common-tags": "^1.8.2",
+          "hono": "^4.12.3",
+          "marked": "^17.0.3",
+          "qrcode": "^1.5.4",
+          "tsx": "^4.21.0"
+        },
+        "dev": {
+          "@biomejs/biome": "2.4.4",
+          "@cloudflare/vitest-pool-workers": "^0.12.18",
+          "@types/common-tags": "^1.8.4",
+          "@types/qrcode": "^1.5.6",
+          "typescript": "^5.9.3",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.69.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/auth.test.ts",
+          "test/env.d.ts",
+          "test/helpers.test.ts",
+          "test/middleware/auth.test.ts",
+          "test/routes/dashboard.test.ts",
+          "test/routes/public.test.ts",
+          "test/schema.test.ts",
+          "test/tsconfig.json",
+          "test/types.test.ts",
+          "test/utils/analytics-cache.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "KV",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "A way to share external links and track interactions using Cloudflare Pipelines",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 23,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 31,
+        "quality": 65,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/test/auth.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/craigsdennis/linkedout-pipelines"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "The Coffee Cluster",
+      "slug": "the-coffee-cluster",
+      "description": "An example Next.js application for PlanetScale with Hyperdrive Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/jillesme/thecoffeecluster",
+      "author": {
+        "name": "jillesme",
+        "github": "jillesme",
+        "avatar": "https://avatars.githubusercontent.com/jillesme"
+      },
+      "shippedDate": "2025-11-24",
+      "youtubeVideo": "https://youtube.com/watch?v=Xps8IAlZ5a8",
+      "stack": {
+        "framework": "Next.js 15",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "pnpm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "orm": "Drizzle ORM"
+      },
+      "dependencies": {
+        "runtime": {
+          "@opennextjs/cloudflare": "^1.17.1",
+          "@planetscale/database": "^1.19.0",
+          "@radix-ui/react-slot": "^1.2.4",
+          "@radix-ui/react-toggle": "^1.1.10",
+          "class-variance-authority": "^0.7.1",
+          "clsx": "^2.1.1",
+          "drizzle-orm": "^0.45.1",
+          "js-cookie": "^3.0.5",
+          "lucide-react": "^0.575.0",
+          "next": "15.5.10",
+          "next-themes": "^0.4.6",
+          "pg": "^8.19.0",
+          "react": "19.2.4",
+          "react-dom": "19.2.4",
+          "sonner": "^2.0.7",
+          "tailwind-merge": "^3.5.0",
+          "zustand": "^5.0.11"
+        },
+        "dev": {
+          "@eslint/eslintrc": "^3.3.4",
+          "@tailwindcss/postcss": "^4.2.1",
+          "@testing-library/jest-dom": "^6.9.1",
+          "@testing-library/react": "^16.3.2",
+          "@testing-library/user-event": "^14.6.1",
+          "@types/js-cookie": "^3.0.6",
+          "@types/node": "^25.3.2",
+          "@types/react": "^19.2.14",
+          "@types/react-dom": "^19",
+          "@vitejs/plugin-react": "^5.1.4",
+          "@vitest/coverage-v8": "^4.0.18",
+          "dotenv": "^17.3.1",
+          "drizzle-kit": "^0.31.9",
+          "eslint": "^9.39.1",
+          "eslint-config-next": "15.5.10",
+          "jsdom": "^28.1.0",
+          "tailwindcss": "^4.2.1",
+          "tsx": "^4.21.0",
+          "tw-animate-css": "^1.4.0",
+          "typescript": "^5",
+          "vitest": "^4.0.18",
+          "wrangler": "^4.69.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "src/app/api/beans/[id]/route.test.ts",
+          "src/app/api/beans/route.test.ts",
+          "src/components/coffee-bean-card.test.tsx",
+          "src/lib/latency-store.test.ts",
+          "src/lib/utils.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "Hyperdrive",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Cloudflare Worker <-> PlanetScale <-> Hyperdrive",
+        "hasWebsite": true,
+        "websiteUrl": "https://thecoffeecluster.com/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 7,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 27,
+        "quality": 70,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/src/app/api/beans/[id]/route.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/.github/workflows/ci.yml"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/jillesme/thecoffeecluster"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://thecoffeecluster.com/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Virtual Try On",
+      "slug": "virtual-try-on",
+      "description": "An app that allows users to try on an ugly winter jumper, virtually! Built with Workers and Replicate Discover what developers are building on Cloudflare.",
+      "url": "https://virtual-try-on.h-demo.workers.dev/",
+      "github": "https://github.com/harshil1712/virtual-try-on-demo",
+      "author": {
+        "name": "harshil1712",
+        "github": "harshil1712",
+        "avatar": "https://avatars.githubusercontent.com/harshil1712"
+      },
+      "shippedDate": "2025-12-23",
+      "stack": {
+        "framework": "React + Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null,
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.11.1",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "replicate": "^1.4.0"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.18.0",
+          "@eslint/js": "^9.33.0",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react-swc": "^4.0.0",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^5.2.0",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^16.3.0",
+          "typescript": "~5.8.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "wrangler": "^4.55.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "google/nano-banana-pro",
+          "openai/gpt-image-1.5"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Virtual try-on app for ugly winter jumpers, built with Workers and Replicate",
+        "hasWebsite": true,
+        "websiteUrl": "https://virtual-try-on.h-demo.workers.dev/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 9,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 32,
+        "quality": 50,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://virtual-try-on.h-demo.workers.dev/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/harshil1712/virtual-try-on-demo/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Site Confidence",
+      "slug": "site-confidence",
+      "description": "Analyze website performance with detailed metrics, waterfall charts, and video recordings, all built on Cloudflare's serverless platform. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/TrickeySolutions/site-page-test",
+      "author": {
+        "name": "TrickeySolutions",
+        "github": "TrickeySolutions",
+        "avatar": "https://avatars.githubusercontent.com/TrickeySolutions"
+      },
+      "shippedDate": "2026-01-12",
+      "stack": {
+        "framework": "Astro",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS"
+      },
+      "dependencies": {
+        "runtime": {
+          "@cloudflare/puppeteer": "^1.0.4",
+          "@astrojs/react": "^4.2.0",
+          "@astrojs/tailwind": "^6.0.0",
+          "astro": "^5.1.0",
+          "react": "^19.0.0",
+          "react-dom": "^19.0.0",
+          "tailwindcss": "^3.4.0"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.8.19",
+          "@cloudflare/workers-types": "^4.20241127.0",
+          "typescript": "^5.5.2",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.56.0",
+          "@types/react": "^19.0.0",
+          "@types/react-dom": "^19.0.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/env.d.ts",
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "R2",
+          "Durable Objects",
+          "Browser Rendering",
+          "Workflows",
+          "Workers AI",
+          "Static Assets",
+          "Containers",
+          "Analytics"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": false,
+        "description": null,
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 2,
+        "forks": 1
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 16,
+        "quality": 30,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/test/env.d.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/TrickeySolutions/site-page-test/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Kivo",
+      "slug": "kivo",
+      "description": "A modern invoicing platform for freelancers and creators. Create professional invoices, track payments, and get paid faster. Discover what developers are building on Cloudflare.",
+      "url": "https://kivo.lauragift.workers.dev",
+      "github": "https://github.com/lauragift21/kivo",
+      "author": {
+        "name": "lauragift21",
+        "github": "lauragift21",
+        "avatar": "https://avatars.githubusercontent.com/lauragift21"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@kivo/shared": "*",
+          "hono": "^4.0.0",
+          "stripe": "^14.10.0",
+          "@fontsource/geist-sans": "^5.2.5",
+          "@fontsource/instrument-serif": "^5.2.8",
+          "@hookform/resolvers": "^3.3.4",
+          "@radix-ui/react-alert-dialog": "^1.0.5",
+          "@radix-ui/react-dialog": "^1.0.5",
+          "@radix-ui/react-dropdown-menu": "^2.0.6",
+          "@radix-ui/react-label": "^2.0.2",
+          "@radix-ui/react-select": "^2.0.0",
+          "@radix-ui/react-slot": "^1.0.2",
+          "@radix-ui/react-tabs": "^1.0.4",
+          "@radix-ui/react-toast": "^1.1.5",
+          "@radix-ui/react-tooltip": "^1.0.7",
+          "@tanstack/react-query": "^5.17.0",
+          "@tanstack/react-router": "^1.15.0",
+          "class-variance-authority": "^0.7.0",
+          "clsx": "^2.1.0",
+          "date-fns": "^3.2.0",
+          "lucide-react": "^0.309.0",
+          "react": "^18.2.0",
+          "react-dom": "^18.2.0",
+          "react-hook-form": "^7.49.3",
+          "tailwind-merge": "^2.2.0",
+          "zod": "^3.22.4"
+        },
+        "dev": {
+          "@types/node": "^20.10.0",
+          "concurrently": "^8.2.2",
+          "eslint": "^8.55.0",
+          "typescript": "^5.3.3",
+          "wrangler": "^4.54.0",
+          "@cloudflare/workers-types": "^4.20240117.0",
+          "vitest": "^1.1.0",
+          "@types/react": "^18.2.47",
+          "@types/react-dom": "^18.2.18",
+          "@vitejs/plugin-react": "^4.2.1",
+          "autoprefixer": "^10.4.16",
+          "postcss": "^8.4.33",
+          "tailwindcss": "^3.4.1",
+          "vite": "^5.0.11"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "apps/api/src/durable-objects/reminder-scheduler.test.ts",
+          "packages/shared/src/utils.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "deploy.yml",
+          "opencode.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "D1",
+          "R2",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets",
+          "Cron Triggers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Modern invoicing for freelancers and independent creators.",
+        "hasWebsite": true,
+        "websiteUrl": "https://kivo.lauragift.workers.dev",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": true,
+        "agentsMdPath": "AGENTS.md",
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 15,
+        "forks": 3
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 34,
+        "quality": 90,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/apps/api/src/durable-objects/reminder-scheduler.test.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/tree/HEAD/.github/workflows"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/AGENTS.md"
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/lauragift21/kivo"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://kivo.lauragift.workers.dev"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "InboxBuddy",
+      "slug": "inboxbuddy",
+      "description": "AI-powered scheduling assistant. Just CC the bot in any email and it handles meeting coordination, calendar checks, and booking automatically. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/whoiskatrin/inboxbuddy",
+      "author": {
+        "name": "whoiskatrin",
+        "github": "whoiskatrin",
+        "avatar": "https://avatars.githubusercontent.com/whoiskatrin"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@anthropic-ai/sdk": "^0.71.2",
+          "agents": "^0.3.3",
+          "mimetext": "^3.0.27",
+          "postal-mime": "^2.7.1"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.8.19",
+          "@types/node": "^25.0.3",
+          "typescript": "^5.5.2",
+          "vitest": "~3.2.0",
+          "wrangler": "^4.54.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/env.d.ts",
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Agents",
+          "D1",
+          "KV",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets",
+          "Email Routing"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "AI Scheduling Assistant ",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 27,
+        "forks": 2
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 32,
+        "quality": 45,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/test/env.d.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/whoiskatrin/inboxbuddy"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Weft",
+      "slug": "weft",
+      "description": "Task management where AI agents do your tasks. Create tasks, assign them to agents, and they work on emails, spreadsheets, PRs, and code. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/jonesphillip/weft",
+      "author": {
+        "name": "jonesphillip",
+        "github": "jonesphillip",
+        "avatar": "https://avatars.githubusercontent.com/jonesphillip"
+      },
+      "shippedDate": "2026-01-08",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null,
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "@anthropic-ai/sdk": "^0.71.2",
+          "@cloudflare/sandbox": "^0.6.7",
+          "jose": "^6.1.3",
+          "react": "^19.1.1",
+          "react-dom": "^19.1.1",
+          "react-router-dom": "^7.11.0",
+          "zod": "^4.3.4"
+        },
+        "dev": {
+          "@cloudflare/vite-plugin": "^1.13.13",
+          "@cloudflare/vitest-pool-workers": "^0.11.1",
+          "@eslint/js": "^9.33.0",
+          "@types/react": "^19.1.10",
+          "@types/react-dom": "^19.1.7",
+          "@vitejs/plugin-react-swc": "^4.0.0",
+          "@vitest/coverage-v8": "3.2",
+          "eslint": "^9.33.0",
+          "eslint-plugin-react-hooks": "^7.0.1",
+          "eslint-plugin-react-refresh": "^0.4.20",
+          "globals": "^17.0.0",
+          "typescript": "^5.9.3",
+          "typescript-eslint": "^8.39.1",
+          "vite": "^7.1.2",
+          "vitest": "3.2",
+          "wrangler": "^4.54.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "tests/mocks/cloudflare-sandbox.ts",
+          "tests/worker/auth.test.ts",
+          "tests/worker/board-access.integration.test.ts",
+          "tests/worker/user-isolation.test.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Sandbox SDK",
+          "Durable Objects",
+          "Workflows",
+          "Workers AI",
+          "Static Assets",
+          "Containers"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Task management, but AI agents do your tasks. Self-host on Cloudflare.",
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": "Apache-2.0",
+        "licensePath": "LICENSE",
+        "stars": 494,
+        "forks": 50
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 90,
+        "quality": 55,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/tests/mocks/cloudflare-sandbox.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/jonesphillip/weft/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Localflare",
+      "slug": "localflare",
+      "description": "Local development dashboard for Cloudflare Workers that lets you inspect and interact with D1, KV, R2, Durable Objects, and Queues during development. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/rohanprasadofficial/localflare",
+      "author": {
+        "name": "rohanprasadofficial",
+        "github": "rohanprasadofficial",
+        "avatar": "https://avatars.githubusercontent.com/rohanprasadofficial"
+      },
+      "shippedDate": "2025-12-29",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "pnpm",
+        "uiLibrary": "Tailwind CSS + Radix UI",
+        "monorepo": true
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.6.14",
+          "cac": "^6.7.14",
+          "ink": "^6.6.0",
+          "ink-spinner": "^5.0.0",
+          "localflare-api": "workspace:*",
+          "localflare-core": "workspace:*",
+          "open": "^10.1.0",
+          "picocolors": "^1.1.1",
+          "react": "^19.0.0",
+          "tiny-jsonc": "^1.0.2",
+          "toml": "^3.0.0",
+          "@base-ui/react": "^1.0.0",
+          "@cloudflare/kumo": "^1.9.0",
+          "@codemirror/autocomplete": "^6.20.0",
+          "@codemirror/commands": "^6.10.1",
+          "@codemirror/lang-sql": "^6.10.0",
+          "@codemirror/state": "^6.5.3",
+          "@codemirror/theme-one-dark": "^6.1.3",
+          "@codemirror/view": "^6.39.8",
+          "@faker-js/faker": "^10.1.0",
+          "@fontsource-variable/figtree": "^5.2.10",
+          "@hugeicons/core-free-icons": "^3.1.0",
+          "@hugeicons/react": "^1.1.4",
+          "@phosphor-icons/react": "^2.1.10",
+          "@radix-ui/react-checkbox": "^1.3.3",
+          "@radix-ui/react-collapsible": "^1.1.12",
+          "@radix-ui/react-dialog": "^1.1.15",
+          "@radix-ui/react-dropdown-menu": "^2.1.16",
+          "@radix-ui/react-popover": "^1.1.15",
+          "@radix-ui/react-scroll-area": "^1.2.2",
+          "@radix-ui/react-select": "^2.2.6",
+          "@radix-ui/react-slot": "^1.1.1",
+          "@radix-ui/react-tabs": "^1.1.2",
+          "@tailwindcss/vite": "^4.1.17",
+          "@tanstack/react-query": "^5.62.8",
+          "@tanstack/react-table": "^8.20.6",
+          "aws4fetch": "^1.0.20",
+          "class-variance-authority": "^0.7.1",
+          "clsx": "^2.1.1",
+          "codemirror": "^6.0.2",
+          "lucide-react": "^0.562.0",
+          "react-dom": "^19.0.0",
+          "react-grid-layout": "^2.2.2",
+          "react-resizable-panels": "^4.4.1",
+          "react-router-dom": "^7.1.1",
+          "recharts": "^2.15.4",
+          "sonner": "^2.0.7",
+          "tailwind-merge": "^3.4.0",
+          "tailwindcss": "^4.1.17",
+          "tw-animate-css": "^1.4.0"
+        },
+        "dev": {
+          "@types/node": "^22.10.2",
+          "turbo": "^2.3.3",
+          "typescript": "^5.7.2",
+          "@cloudflare/workers-types": "^4.20241218.0",
+          "localflare-core": "workspace:*",
+          "tsup": "^8.3.5",
+          "@types/react": "^19.0.2",
+          "@types/react-dom": "^19.0.2",
+          "@types/react-grid-layout": "^2.1.0",
+          "@vitejs/plugin-react": "^4.3.4",
+          "vite": "^6.0.6",
+          "wrangler": "^3.99.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "local cloudflare",
+        "hasWebsite": true,
+        "websiteUrl": "https://localflare.dev",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": "MIT",
+        "licensePath": "LICENSE",
+        "stars": 1519,
+        "forks": 70
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 100,
+        "quality": 60,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://localflare.dev"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/rohanprasadofficial/localflare/blob/HEAD/LICENSE"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Keyboardia",
+      "slug": "keyboardia",
+      "description": "A multiplayer step sequencer with polyrhythmic patterns, built for real-time collaboration. Create/Collaborate. Remix. Share. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/adewale/keyboardia",
+      "author": {
+        "name": "adewale",
+        "github": "adewale",
+        "avatar": "https://avatars.githubusercontent.com/adewale"
+      },
+      "shippedDate": "2025-12-17",
+      "stack": {
+        "framework": "React 19",
+        "language": "TypeScript",
+        "buildTool": "Vite",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "@types/qrcode": "^1.5.6",
+          "midi-writer-js": "^3.1.1",
+          "qrcode": "^1.5.4",
+          "react": "^19.2.1",
+          "react-dom": "^19.2.1",
+          "tone": "^15.1.22",
+          "workers-og": "^0.0.27"
+        },
+        "dev": {
+          "@eslint/js": "^9.39.1",
+          "@playwright/test": "^1.57.0",
+          "@testing-library/react": "^16.3.0",
+          "@types/node": "^24.10.1",
+          "@types/react": "^19.2.7",
+          "@types/react-dom": "^19.2.3",
+          "@vitejs/plugin-react": "^5.1.1",
+          "eslint": "^9.39.1",
+          "eslint-plugin-react-hooks": "^7.0.1",
+          "eslint-plugin-react-refresh": "^0.4.24",
+          "fast-check": "^4.5.3",
+          "globals": "^16.5.0",
+          "husky": "^9.1.7",
+          "jsdom": "^27.3.0",
+          "lint-staged": "^16.2.7",
+          "midi-file": "^1.2.4",
+          "ts-morph": "^27.0.2",
+          "tsx": "^4.21.0",
+          "typescript": "~5.9.3",
+          "typescript-eslint": "^8.46.4",
+          "vite": "^7.2.4",
+          "vitest": "^4.0.15",
+          "wrangler": "^4.53.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest + playwright",
+        "testFiles": [
+          "app/e2e/accessibility.spec.ts",
+          "app/e2e/chromatic-grid.spec.ts",
+          "app/e2e/connection-storm.spec.ts",
+          "app/e2e/core.spec.ts",
+          "app/e2e/drag-to-paint.spec.ts",
+          "app/e2e/feature-flags.spec.ts",
+          "app/e2e/keyboard.spec.ts",
+          "app/e2e/landscape-alignment.spec.ts",
+          "app/e2e/last-cell-flicker.spec.ts",
+          "app/e2e/mobile-android.spec.ts"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "R2",
+          "KV",
+          "Durable Objects",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Multiplayer step sequencer with polyrhythmic patterns for real-time collaboration",
+        "hasWebsite": true,
+        "websiteUrl": "https://keyboardia.dev/",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": false,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 2,
+        "forks": 0
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 5,
+        "quality": 60,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/app/e2e/accessibility.spec.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/.github/workflows/ci.yml"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/adewale/keyboardia"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://keyboardia.dev/"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Webhookflare",
+      "slug": "webhookflare",
+      "description": "Webhook testing and debugging tool built with Cloudflare Durable Objects, demonstrating the power of edge computing with persistent SQLite storage and real-time WebSocket updates. Discover what developers are building on Cloudflare.",
+      "url": "https://webhookflare.fayaz.workers.dev/",
+      "github": "https://github.com/fayazara/webhookflare",
+      "author": {
+        "name": "fayazara",
+        "github": "fayazara",
+        "avatar": "https://avatars.githubusercontent.com/fayazara"
+      },
+      "shippedDate": "2025-11-19",
+      "stack": {
+        "framework": "Workers",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "pnpm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {},
+        "dev": {
+          "typescript": "^5.5.2",
+          "wrangler": "^4.47.0"
+        }
+      },
+      "testing": {
+        "hasTests": false,
+        "framework": null,
+        "testFiles": []
+      },
+      "ci": {
+        "hasGitHubActions": false,
+        "workflows": []
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Durable Objects",
+          "Rate Limiting",
+          "Workers AI",
+          "Static Assets"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": false,
+        "models": [],
+        "apiIntegration": null
+      },
+      "hygiene": {
+        "hasDescription": false,
+        "description": null,
+        "hasWebsite": false,
+        "websiteUrl": null,
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": false,
+        "license": null,
+        "licensePath": null,
+        "stars": 8,
+        "forks": 5
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 38,
+        "quality": 20,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": false
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/webhookflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/fayazara/webhookflare/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": false
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "Kontext Realtime",
+      "slug": "kontext-realtime",
+      "description": "Create and edit images using your voice. Discover what developers are building on Cloudflare.",
+      "url": "https://fonts.googleapis.com",
+      "github": "https://github.com/replicate/kontext-realtime",
+      "author": {
+        "name": "replicate",
+        "github": "replicate",
+        "avatar": "https://avatars.githubusercontent.com/replicate"
+      },
+      "shippedDate": "2025-07-02",
+      "youtubeVideo": "https://youtube.com/watch?v=72mD_vkG9FU",
+      "stack": {
+        "framework": "Hono",
+        "language": "TypeScript",
+        "buildTool": "wrangler",
+        "packageManager": "npm",
+        "uiLibrary": null
+      },
+      "dependencies": {
+        "runtime": {
+          "hono": "^4.6.13",
+          "replicate": "^2.0.0-alpha.16"
+        },
+        "dev": {
+          "@cloudflare/vitest-pool-workers": "^0.5.2",
+          "typescript": "^5.5.2",
+          "vitest": "2.1.8",
+          "wrangler": "^4.6.0"
+        }
+      },
+      "testing": {
+        "hasTests": true,
+        "framework": "vitest",
+        "testFiles": [
+          "test/index.spec.ts",
+          "test/tsconfig.json"
+        ]
+      },
+      "ci": {
+        "hasGitHubActions": true,
+        "workflows": [
+          "ci.yml",
+          "claude.yml"
+        ]
+      },
+      "cloudflare": {
+        "products": [
+          "Workers",
+          "Static Assets",
+          "Realtime"
+        ],
+        "bindings": {}
+      },
+      "replicate": {
+        "usesReplicate": true,
+        "models": [
+          "black-forest-labs/flux-kontext-pro",
+          "black-forest-labs/flux-schnell",
+          "topazlabs/image-upscale"
+        ],
+        "apiIntegration": "replicate npm package"
+      },
+      "hygiene": {
+        "hasDescription": true,
+        "description": "Create and edit images using your voice",
+        "hasWebsite": true,
+        "websiteUrl": "https://replicate.com/docs/guides/openai-realtime",
+        "hasReadme": true,
+        "readmePath": "README.md",
+        "hasAgentsMd": false,
+        "agentsMdPath": null,
+        "readmeHasImage": true,
+        "readmeHasVideo": true,
+        "license": null,
+        "licensePath": null,
+        "stars": 106,
+        "forks": 26
+      },
+      "tags": [],
+      "scores": {
+        "popularity": 73,
+        "quality": 70,
+        "qualityBreakdown": [
+          {
+            "id": "tests",
+            "label": "Automated tests",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/test/index.spec.ts"
+          },
+          {
+            "id": "ci",
+            "label": "Continuous integration",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/tree/HEAD/.github/workflows"
+          },
+          {
+            "id": "readme",
+            "label": "README documentation",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/README.md"
+          },
+          {
+            "id": "agentsmd",
+            "label": "AGENTS.md instructions",
+            "points": 20,
+            "earned": false
+          },
+          {
+            "id": "readme-media",
+            "label": "README images or videos",
+            "points": 10,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime/blob/HEAD/README.md"
+          },
+          {
+            "id": "description",
+            "label": "Repository description",
+            "points": 15,
+            "earned": true,
+            "href": "https://github.com/replicate/kontext-realtime"
+          },
+          {
+            "id": "website",
+            "label": "Project website",
+            "points": 15,
+            "earned": true,
+            "href": "https://replicate.com/docs/guides/openai-realtime"
+          },
+          {
+            "id": "license",
+            "label": "License file",
+            "points": 10,
+            "earned": false
+          }
+        ]
+      }
+    }
+  ],
   "summary": {
-    "byFramework": {},
-    "byLanguage": {},
-    "byPackageManager": {},
-    "byBuildTool": {},
-    "cloudflareProducts": {},
+    "byFramework": {
+      "React 19": 3,
+      "Unknown": 1,
+      "Express": 1,
+      "React + Hono": 2,
+      "Hono": 3,
+      "Next.js 15": 1,
+      "Astro": 1,
+      "Workers": 3
+    },
+    "byLanguage": {
+      "TypeScript": 14,
+      "Unknown": 1
+    },
+    "byPackageManager": {
+      "npm": 12,
+      "pnpm": 3
+    },
+    "byBuildTool": {
+      "Vite": 9,
+      "Unknown": 1,
+      "wrangler": 5
+    },
+    "cloudflareProducts": {
+      "Workers": 15,
+      "Static Assets": 13,
+      "Agents": 2,
+      "R2": 6,
+      "Durable Objects": 7,
+      "Workflows": 3,
+      "Cloudflare Images": 1,
+      "Workers AI": 11,
+      "D1": 4,
+      "KV": 3,
+      "Hyperdrive": 1,
+      "Browser Rendering": 1,
+      "Containers": 2,
+      "Analytics": 1,
+      "Cron Triggers": 1,
+      "Email Routing": 1,
+      "Sandbox SDK": 1,
+      "Rate Limiting": 1,
+      "Realtime": 1
+    },
     "testing": {
-      "withTests": 0,
-      "withoutTests": 0,
-      "testFrameworks": {}
+      "withTests": 9,
+      "withoutTests": 6,
+      "testFrameworks": {
+        "vitest": 9,
+        "playwright": 1
+      }
     },
     "ci": {
-      "withGitHubActions": 0,
-      "withoutGitHubActions": 0
+      "withGitHubActions": 4,
+      "withoutGitHubActions": 11
     },
     "replicate": {
-      "appsUsingReplicate": 0,
-      "totalModels": 0,
-      "uniqueModels": []
+      "appsUsingReplicate": 3,
+      "totalModels": 6,
+      "uniqueModels": [
+        "black-forest-labs/flux-kontext-pro",
+        "black-forest-labs/flux-schnell",
+        "bytedance/seedream-4.5",
+        "google/nano-banana-pro",
+        "openai/gpt-image-1.5",
+        "topazlabs/image-upscale"
+      ]
     },
     "hygiene": {
-      "withDescription": 0,
-      "withWebsite": 0,
-      "withReadme": 0,
-      "withAgentsMd": 0,
-      "withImage": 0,
-      "withVideo": 0
+      "withDescription": 13,
+      "withWebsite": 7,
+      "withReadme": 15,
+      "withAgentsMd": 3,
+      "withImage": 12,
+      "withVideo": 5
     },
     "scores": {
       "popularity": {


### PR DESCRIPTION
## What

Fix Small App Garden slug scraping so data collection works against the current Garden HTML, and regenerate the published app data.

## Why

Production was deploying successfully, but rendering `0 apps`.

Root cause:
- `fetchGardenSlugs()` only looked for legacy links shaped like `href="/garden/{slug}"`
- the current Garden homepage now exposes apps as root-relative links like `href="/{slug}/"`
- app cards also expose `data-slug="..."`
- because the old regex no longer matched, the collector found `0` slugs, wrote an empty `apps.json`, and deploy published an empty site

## How

### Red-green TDD

I added focused tests first for slug parsing:
- legacy `href="/garden/{slug}"` links still parse
- current Garden markup parses app slugs from:
  - `data-slug="..."`
  - root-relative app links like `href="/inboxbuddy/"`
- non-app routes like `/submit` are excluded

Then I updated the collector to make those tests pass.

### Collector changes

In `collect-data.ts`:
- extracted slug parsing into `parseGardenSlugs(html)`
- supported all of these patterns:
  - legacy `/garden/{slug}` links
  - current `data-slug="..."` card attributes
  - current root-relative `/{slug}/` app links
- continued filtering non-app entries like `submit`
- updated app detail fetches to use `${GARDEN_URL}${slug}/`
- gated `main()` so tests can import collector helpers without running the script

### Data refresh

Ran `npm run collect` after the scraper fix, which regenerated:
- `apps.json`
- `website/src/data.json`

This restored the dataset from `0` apps to `15` apps.

## Testing

Commands run:

```bash
npm test
npm run collect
npm test
```

Results:
- before regenerating data, the new slug-parser tests passed, and the existing `apps.json has apps` check still failed because the repo was carrying empty data
- after `npm run collect`, the full test suite passed

Final result:
- `16 passed, 0 failed`

## Risk

Low to moderate.

This changes shared scraping logic, so the main risk is accidentally capturing non-app root routes. Mitigations:
- tests cover both old and new slug shapes
- `submit` is explicitly excluded
- parsing still dedupes slugs via `Set`
- regenerated data confirms the scraper now returns real apps again

## Files changed

- `collect-data.ts`
- `test.ts`
- `apps.json`
- `website/src/data.json`
